### PR TITLE
change availability zones to just letters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [v0.5.2] - 2022-11-10
+
+### Changed
+
+- `-z` or `--availability-zones` accepts **only** letters to represent the availability zone. It will be append to the current region. For example, if you are searching in `us-east-1` and you want to search in `us-east-1a` you can use `-z a`.
+
 ## [v0.5.1] - 2022-10-24
 
 <!-- markdownlint-disable MD024 -->

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It is a wrapper written in Go using AWS SDK Go v2. The work is still in progress
 ## Version
 
 <!-- Do not forget to update version on commands/commands.go Version -->
-The current version is 0.5.1
+The current version is 0.5.2
 
 ## Features
 

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -34,7 +34,7 @@ You can also pass 'all' to iterate over all regions.
 You can find the source code on GitHub:
 https://github.com/dyegoe/awss`,
 	// Remember to update this version when releasing a new version
-	Version: "0.5.1",
+	Version: "0.5.2",
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		err := initConfig()
 		if err != nil {

--- a/commands/ec2.go
+++ b/commands/ec2.go
@@ -34,7 +34,7 @@ tags Key=Value1:Value2 and Environment=Production, you can use:
 	awss ec2 -t 'Key=Value1:Value2,Environment=Production'
 instance type t2.micro and t2.small, you can use:
 	awss ec2 -T t2.micro,t2.small
-availability zone us-east-1a and us-east-1b, you can use:
+availability zones us-east-1a and us-east-1b, you can use:
 	awss --region us-east-1 ec2 -z a,b
 instance state running and stopped, you can use:
 	awss ec2 -s running,stopped
@@ -100,7 +100,7 @@ func init() {
 	ec2Cmd.Flags().StringSliceVarP(&ec2Names, "names", "n", []string{}, "Filter EC2 instances by names. It searchs using the 'tag:Name'. `instance-1,instance-2`")
 	ec2Cmd.Flags().StringSliceVarP(&ec2Tags, "tags", "t", []string{}, "Filter EC2 instances by tags. `'Key=Value1:Value2,Environment=Production'`")
 	ec2Cmd.Flags().StringSliceVarP(&ec2InstanceTypes, "instance-types", "T", []string{}, "Filter EC2 instances by instance type. `t2.micro,t2.small`")
-	ec2Cmd.Flags().StringSliceVarP(&ec2AvailabilityZones, "availability-zones", "z", []string{}, "Filter EC2 instances by availability zone. It will append to current region. `a,b`")
+	ec2Cmd.Flags().StringSliceVarP(&ec2AvailabilityZones, "availability-zones", "z", []string{}, "Filter EC2 instances by availability zones. It will append to current region. `a,b`")
 	ec2Cmd.Flags().StringSliceVarP(&ec2InstanceStates, "instance-states", "s", []string{}, "Filter EC2 instances by instance state. `running,stopped`")
 	ec2Cmd.Flags().IPSliceVarP(&ec2PrivateIps, "private-ips", "p", []net.IP{}, "Filter EC2 instances by private IPs. `172.16.0.1,172.17.1.254`")
 	ec2Cmd.Flags().IPSliceVarP(&ec2PublicIps, "public-ips", "P", []net.IP{}, "Filter EC2 instances by public IPs. `52.28.19.20,52.30.31.32`")

--- a/commands/ec2.go
+++ b/commands/ec2.go
@@ -35,7 +35,7 @@ tags Key=Value1:Value2 and Environment=Production, you can use:
 instance type t2.micro and t2.small, you can use:
 	awss ec2 -T t2.micro,t2.small
 availability zone us-east-1a and us-east-1b, you can use:
-	awss ec2 -z us-east-1a,us-east-1b
+	awss --region us-east-1 ec2 -z a,b
 instance state running and stopped, you can use:
 	awss ec2 -s running,stopped
 private IPs 172.16.0.1 and 172.17.1.254, you can use:
@@ -44,7 +44,7 @@ public IPs 52.28.19.20 and 52.30.31.32, you can use:
 	awss ec2 -P 52.28.19.20,52.30.31.32
 
 You can use multiple filters at same time, for example:
-	awss ec2 -n '*' -t 'Key=Value1:Value2,Environment=Production' -T t2.micro,t2.small -z us-east-1a,us-east-1b -s running,stopped
+	awss ec2 -n '*' -t 'Key=Value1:Value2,Environment=Production' -T t2.micro,t2.small -z a,b -s running,stopped
 	(You can use the wildcard '*' to search for all values in a filter)
 `,
 	Args: cobra.NoArgs,
@@ -100,7 +100,7 @@ func init() {
 	ec2Cmd.Flags().StringSliceVarP(&ec2Names, "names", "n", []string{}, "Filter EC2 instances by names. It searchs using the 'tag:Name'. `instance-1,instance-2`")
 	ec2Cmd.Flags().StringSliceVarP(&ec2Tags, "tags", "t", []string{}, "Filter EC2 instances by tags. `'Key=Value1:Value2,Environment=Production'`")
 	ec2Cmd.Flags().StringSliceVarP(&ec2InstanceTypes, "instance-types", "T", []string{}, "Filter EC2 instances by instance type. `t2.micro,t2.small`")
-	ec2Cmd.Flags().StringSliceVarP(&ec2AvailabilityZones, "availability-zones", "z", []string{}, "Filter EC2 instances by availability zone. `us-east-1a,us-east-1b`")
+	ec2Cmd.Flags().StringSliceVarP(&ec2AvailabilityZones, "availability-zones", "z", []string{}, "Filter EC2 instances by availability zone. It will append to current region. `a,b`")
 	ec2Cmd.Flags().StringSliceVarP(&ec2InstanceStates, "instance-states", "s", []string{}, "Filter EC2 instances by instance state. `running,stopped`")
 	ec2Cmd.Flags().IPSliceVarP(&ec2PrivateIps, "private-ips", "p", []net.IP{}, "Filter EC2 instances by private IPs. `172.16.0.1,172.17.1.254`")
 	ec2Cmd.Flags().IPSliceVarP(&ec2PublicIps, "public-ips", "P", []net.IP{}, "Filter EC2 instances by public IPs. `52.28.19.20,52.30.31.32`")

--- a/search/ec2.go
+++ b/search/ec2.go
@@ -101,10 +101,14 @@ func (i *instances) filterByInstanceTypes(instanceTypes []string) []types.Filter
 
 // filterByAvailabilityZones returns filters by availability zone
 func (i *instances) filterByAvailabilityZones(availabilityZones []string) []types.Filter {
+	var azs []string
+	for _, value := range availabilityZones {
+		azs = append(azs, fmt.Sprintf("%s%s", i.Region, value))
+	}
 	return []types.Filter{
 		{
 			Name:   aws.String("availability-zone"),
-			Values: availabilityZones,
+			Values: azs,
 		},
 	}
 }


### PR DESCRIPTION
Now, the option `-z` or `--availability-zones`  accepts *only* letters that will be append to the current region.
The region might be the default region, specified through `--regions` or for each region from `--regions all`