### PR TITLE
38-Move-sort_ec2_by-to-ec2sort_by

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 <!-- markdownlint-disable MD024 -->
 ### Added
 
-- Add EC2 sorting. You can sort the results by instance id, name, type, state, az, private ip and public ip. `--sort` or `-S` flag.
-- You can change the default sorting field in the configuration file. `sort_ec2_by` field.
+- Add EC2 sorting. You can sort the results by instance id, name, type, state, az, private ip and public ip. `--sort` flag.
+- You can change the default sorting field in the configuration file. `ec2.sort_by` field.
 - Add EC2 `--show-tags` flag to show the tags in the output.
 
 <!-- markdownlint-disable MD024 -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - Add EC2 sorting. You can sort the results by instance id, name, type, state, az, private ip and public ip. `--sort` flag.
-- You can change the default sorting field in the configuration file. `ec2.sort_by` field.
-- Add EC2 `--show-tags` flag to show the tags in the output.
+  - You can change the default sorting field in the configuration file. `ec2.sort_by` field.
+- Add EC2 `--show-tags` flag to show the tags in the output. (default: false)
+  - You can change the default `--show-tags` value in the configuration file. `ec2.show_tags` field.
 
 <!-- markdownlint-disable MD024 -->
 ### Changed

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ all_regions:
   - ap-northeast-3
   - ap-northeast-2
   - ap-northeast-1
-sort_ec2_by: name
 ec2:
+  sort_by: name
   show_tags: false
 ```
 

--- a/commands/ec2.go
+++ b/commands/ec2.go
@@ -86,7 +86,7 @@ You can use multiple filters at same time, for example:
 			return fmt.Errorf("you must specify at least one filter")
 		}
 
-		err := search.Run(viper.GetStringSlice("profiles"), viper.GetStringSlice("regions"), viper.GetString("output"), viper.GetBool("show-empty"), cmd.Name(), searchBy, viper.GetString("sort_ec2_by"))
+		err := search.Run(viper.GetStringSlice("profiles"), viper.GetStringSlice("regions"), viper.GetString("output"), viper.GetBool("show-empty"), cmd.Name(), searchBy, viper.GetString("ec2.sort_by"))
 		if err != nil {
 			return fmt.Errorf("something went wrong while running %s. error: %v", cmd.Name(), err)
 		}
@@ -104,10 +104,10 @@ func init() {
 	ec2Cmd.Flags().StringSliceVarP(&ec2InstanceStates, "instance-states", "s", []string{}, "Filter EC2 instances by instance state. `running,stopped`")
 	ec2Cmd.Flags().IPSliceVarP(&ec2PrivateIps, "private-ips", "p", []net.IP{}, "Filter EC2 instances by private IPs. `172.16.0.1,172.17.1.254`")
 	ec2Cmd.Flags().IPSliceVarP(&ec2PublicIps, "public-ips", "P", []net.IP{}, "Filter EC2 instances by public IPs. `52.28.19.20,52.30.31.32`")
-	ec2Cmd.Flags().StringP("sort", "S", "name", "Sort EC2 instances by id, name, type, az, state, private-ip or public-ip. `name`")
+	ec2Cmd.Flags().String("sort", "name", "Sort EC2 instances by id, name, type, az, state, private-ip or public-ip. `name`")
 	ec2Cmd.Flags().Bool("show-tags", false, "Show EC2 instances tags. `false`")
 	// Bind flags to viper
-	viper.BindPFlag("sort_ec2_by", ec2Cmd.Flags().Lookup("sort"))
+	viper.BindPFlag("ec2.sort_by", ec2Cmd.Flags().Lookup("sort"))
 	viper.BindPFlag("ec2.show_tags", ec2Cmd.Flags().Lookup("show-tags"))
 }
 


### PR DESCRIPTION
Besides the adjust of `ec2.sort_by`, the `README.md` was fixed because a `ec2.show_tags` was missing.