### PR TITLE
feat(cmd): make --profiles/--regions optional with env-based fallback

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,6 +46,10 @@ const (
 	labelShowTagsCobra  = "show-tags"
 	labelShowTags       = "show.tags"
 	labelAllRegions     = "all-regions"
+
+	// defaultRegion is used when no --regions flag, AWS_REGION, or
+	// AWS_DEFAULT_REGION is set.
+	defaultRegion = "us-east-1"
 )
 
 // version is overridden at build time via -ldflags.
@@ -139,10 +143,16 @@ func initFlags() {
 
 	rootCmd.PersistentFlags().String(labelConfig, "",
 		"config file path (default is $HOME/.awss/config.yaml)")
-	rootCmd.PersistentFlags().StringSlice(labelProfiles, []string{"default"},
-		"Select the profile from ~/.aws/config. You can pass multiple profiles separated by comma. e.g. `profile1,profile2`")
-	rootCmd.PersistentFlags().StringSlice(labelRegions, []string{"us-east-1"},
-		"Select a region to perform your API calls. You can pass multiple regions separated by comma. e.g. `region1,region2`")
+	rootCmd.PersistentFlags().StringSlice(labelProfiles, []string{},
+		"Select the profile from ~/.aws/config. You can pass multiple profiles separated by comma. "+
+			"e.g. `profile1,profile2`. If not set, falls back to the AWS SDK's default credential "+
+			"resolution (AWS_PROFILE, static env credentials, or the `default` profile).")
+	rootCmd.PersistentFlags().StringSlice(labelRegions, []string{},
+		fmt.Sprintf(
+			"Select a region to perform your API calls. You can pass multiple regions separated by comma. "+
+				"e.g. `region1,region2`. If not set, falls back to AWS_REGION/AWS_DEFAULT_REGION, or %s.",
+			defaultRegion,
+		))
 	rootCmd.PersistentFlags().String(labelOutput, "table",
 		fmt.Sprintf("Select the output format. Valid outputs are: %s", validOutputs))
 	rootCmd.PersistentFlags().Bool(labelShowEmptyCobra, false,
@@ -239,12 +249,17 @@ var getAwsProfiles = common.GetAwsProfiles
 
 // checkProfiles checks if the profiles are valid.
 //
+// If the user passes no profile, it returns a single empty-string profile so
+// the AWS SDK resolves credentials itself, in order: AWS_PROFILE, static
+// AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY env vars, or the `default` profile.
+// This is intentionally not validated against ~/.aws/config, since that file
+// may not exist when credentials come purely from the environment.
 // If the user passes the `all` profile, it will return all the profiles.
 // If the user passes a list of profiles, it will check if they are valid and return them.
 // It compares the profiles passed by the user with the profiles found in the config file.
 func checkProfiles(profiles []string) ([]string, error) {
 	if len(profiles) == 0 {
-		return nil, fmt.Errorf("no profile selected")
+		return []string{""}, nil
 	}
 
 	awsProfiles, err := getAwsProfiles()
@@ -264,14 +279,31 @@ func checkProfiles(profiles []string) ([]string, error) {
 	return profiles, nil
 }
 
+// getAwsRegionEnv returns the region from the AWS_REGION or AWS_DEFAULT_REGION
+// environment variables, in that order of precedence, matching the AWS SDK's
+// own resolution order. It returns an empty string when neither is set.
+//
+// We use a variable to mock it in the tests.
+var getAwsRegionEnv = func() string {
+	if region := os.Getenv("AWS_REGION"); region != "" {
+		return region
+	}
+	return os.Getenv("AWS_DEFAULT_REGION")
+}
+
 // checkRegions checks if the regions are valid.
 //
+// If the user passes no region, it falls back to AWS_REGION/AWS_DEFAULT_REGION,
+// or defaultRegion, and that single region is not validated against allRegions.
 // If the user passes the `all` region, it will return all the regions.
 // If the user passes a list of regions, it will check if they are valid and return them.
 // It compares the regions passwd by the user with the all-regions list in the config file.
 func checkRegions(regions, allRegions []string) ([]string, error) {
 	if len(regions) == 0 {
-		return nil, fmt.Errorf("no region selected")
+		if region := getAwsRegionEnv(); region != "" {
+			return []string{region}, nil
+		}
+		return []string{defaultRegion}, nil
 	}
 
 	if len(regions) == 1 && regions[0] == "all" {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -80,8 +80,8 @@ func Test_checkProfiles(t *testing.T) {
 		{
 			name:    "empty",
 			args:    args{profiles: []string{}},
-			want:    nil,
-			wantErr: true,
+			want:    []string{""},
+			wantErr: false,
 		},
 		{
 			name:    "all",
@@ -124,6 +124,11 @@ func Test_checkProfiles(t *testing.T) {
 
 // Test_checkRegions tests the checkRegions function.
 func Test_checkRegions(t *testing.T) {
+	// save the original variable, defer the restore and mock the variable
+	oldGetAwsRegionEnv := getAwsRegionEnv
+	defer func() { getAwsRegionEnv = oldGetAwsRegionEnv }()
+	getAwsRegionEnv = func() string { return "" }
+
 	allRegions := []string{"us-east-1", "us-east-2"}
 
 	type args struct {
@@ -137,10 +142,10 @@ func Test_checkRegions(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "empty",
+			name:    "empty falls back to defaultRegion",
 			args:    args{regions: []string{}, allRegions: allRegions},
-			want:    nil,
-			wantErr: true,
+			want:    []string{defaultRegion},
+			wantErr: false,
 		},
 		{
 			name:    "us-east-1",
@@ -178,6 +183,23 @@ func Test_checkRegions(t *testing.T) {
 				t.Errorf("checkRegions()\n%#v\nwant\n%#v", got, tt.want)
 			}
 		})
+	}
+}
+
+// Test_checkRegions_envFallback tests that checkRegions uses AWS_REGION/AWS_DEFAULT_REGION,
+// bypassing the allRegions validation, when no --regions flag is passed.
+func Test_checkRegions_envFallback(t *testing.T) {
+	oldGetAwsRegionEnv := getAwsRegionEnv
+	defer func() { getAwsRegionEnv = oldGetAwsRegionEnv }()
+	getAwsRegionEnv = func() string { return "af-south-1" }
+
+	got, err := checkRegions([]string{}, []string{"us-east-1", "us-east-2"})
+	if err != nil {
+		t.Fatalf("checkRegions() unexpected error = %v", err)
+	}
+	want := []string{"af-south-1"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("checkRegions()\n%#v\nwant\n%#v", got, want)
 	}
 }
 

--- a/common/aws.go
+++ b/common/aws.go
@@ -72,6 +72,9 @@ var defaultSharedConfigFilename = config.DefaultSharedConfigFilename()
 //
 // It is used to get the list of profiles from the AWS config file.
 // The default location is ~/.aws/config.
+//
+// Named profiles are stored as `[profile name]` sections, while the default
+// profile is stored as a bare `[default]` section, so both forms are matched.
 func GetAwsProfiles() ([]string, error) {
 	cfg, err := ini.Load(defaultSharedConfigFilename)
 	if err != nil {
@@ -79,7 +82,10 @@ func GetAwsProfiles() ([]string, error) {
 	}
 	profiles := []string{}
 	for _, section := range cfg.Sections() {
-		if strings.HasPrefix(section.Name(), "profile ") {
+		switch {
+		case section.Name() == "default":
+			profiles = append(profiles, "default")
+		case strings.HasPrefix(section.Name(), "profile "):
 			profiles = append(profiles, strings.TrimPrefix(section.Name(), "profile "))
 		}
 	}

--- a/common/testdata/config
+++ b/common/testdata/config
@@ -1,4 +1,4 @@
-[profile default]
+[default]
 region = eu-central-1
 
 [profile profile1]


### PR DESCRIPTION
## Summary
- `--profiles` and `--regions` are now optional. When omitted, `awss` no longer requires `~/.aws/config` to exist or contain a matching profile — it lets the AWS SDK resolve credentials itself (`AWS_PROFILE`, static `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` env vars, or the `default` profile), and picks up `AWS_REGION`/`AWS_DEFAULT_REGION` before falling back to `us-east-1`.
- Fixed `common.GetAwsProfiles` to also match the bare `[default]` INI section (real `~/.aws/config` files use `[default]`, not `[profile default]`), so explicit `--profiles default` now works against a normal config file too. The test fixture was previously using the non-standard `[profile default]` form, which masked this.

## Root cause
`checkProfiles` always called `getAwsProfiles()` (reads `~/.aws/config`) even when the user didn't pass `--profiles`, and validated the default `"default"` value against it — but `GetAwsProfiles` never returned `"default"` for a real config file, and errored outright if the file didn't exist. `--regions` had a hardcoded default and never consulted `AWS_REGION`. `common.AwsConfig` already handled empty profile/region correctly via the AWS SDK's own resolution chain — the CLI-layer validation was the only blocker.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `golangci-lint run`
- [x] Manually ran the built binary with `HOME` pointed at a dir with no `~/.aws/config`, only `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_REGION` set — it passed profile/region resolution and made a real STS call in the requested region (rejected only due to fake credentials).